### PR TITLE
feat: start api and web processes automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,10 +31,12 @@
     "redux-thunk": "2.3.0"
   },
   "scripts": {
-    "start": "env-cmd ./.env.local react-scripts start",
-    "start:local": "yarn start",
+    "start": "run-s tab:start:api tab:start:local",
+    "start:local": "env-cmd ./.env.local react-scripts start",
     "start:api": "json-server --watch data/db.json --port 3636 --id _id --routes data/routes.json",
     "prestart:api": "cat data/default.json > data/db.json",
+    "tab:start:api": "ttab -t 'Graasp API' -G npm run start:api",
+    "tab:start:local": "ttab -t 'Graasp App' -G npm run start:local",
     "build": "run-s build:react build:bundle",
     "build:react": "react-scripts build",
     "build:bundle": "webpack --config webpack.config.js --mode=production",
@@ -75,6 +77,7 @@
     "pretty-quick": "1.10.0",
     "script-ext-html-webpack-plugin": "2.1.3",
     "standard-version": "4.4.0",
+    "ttab": "0.6.1",
     "uglifyjs-webpack-plugin": "2.1.1",
     "webpack-cli": "3.2.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11412,6 +11412,11 @@ tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
+ttab@0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/ttab/-/ttab-0.6.1.tgz#72001a333d477a92c49f6cb0e83ae07984c66be5"
+  integrity sha512-9JvkYlhFMrmrgINQUn5ZJqVVtH+BDpGeFrDhlAaiR0/NgB4TfwU9gNv5Vwuel7gWs8wohEmwWiJuWPtV0swwyw==
+
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"


### PR DESCRIPTION
When user runs `yarn start`, start both the API and web processes.

closes #70